### PR TITLE
Add SQL for listing unpopular books

### DIFF
--- a/task/README.md
+++ b/task/README.md
@@ -1,0 +1,20 @@
+# SQLタスク
+
+## 必要なツール・ライブラリ
+Apache Derby. 環境変数 `$DERBY_HOME`, `$PATH` の設定を行ってください。以下は一例です。
+
+```
+export DERBY_HOME=/Users/PJS/sdk/db-derby-10.5.3.0-bin
+export PATH="$DERBY_HOME/bin:$PATH"
+```
+
+## 実行方法
+このディレクトリ内の `.sql` ファイルはDerbyのコマンドラインツール `ij` で以下のように実行可能です。
+```
+ij < task/list_unpopular_books.sql
+```
+
+実行結果は必要に応じて整形し、ファイルに保存してください。
+```
+ij < task/list_unpopular_books.sql | perl -p -e 's/\s+\|/<>/g; s/\t/ /g; s/<>/\t/g;' > out.tsv
+```

--- a/task/list_unpopular_books.sql
+++ b/task/list_unpopular_books.sql
@@ -1,0 +1,58 @@
+-- 貸出回数が少ない図書のリスト（過去5年間における、貸出回数が0～5回の図書のリスト）
+--
+-- 目的：図書室全体の蔵書整理を実施する際の参考のため。
+-- 出力項目：蔵書番号, 題名, 著者, 出版社, 登録年, 貸出回数
+-- 備考：例年、8/20頃までに必要。
+
+CONNECT 'jdbc:derby:../PJS-DB/pjsLibraryDB';
+
+-- 貸出回数0回の本
+SELECT
+  Book.id,
+  Book.title,
+  Book.authors,
+  Book.publisher,
+  YEAR(Book.register_date),
+  0
+FROM
+  Book
+WHERE
+  discard_date IS NULL
+  AND NOT EXISTS(
+    SELECT
+      1
+    FROM
+      CheckoutHistory
+    WHERE
+      Book.id = CheckoutHistory.book_id
+    )
+  ORDER BY
+    Book.id ASC;
+
+-- 貸出回数1〜5回の本
+SELECT
+  Book.id,
+  Book.title,
+  Book.authors,
+  Book.publisher,
+  YEAR(Book.register_date),
+  Count(*)
+FROM
+  CheckoutHistory
+INNER JOIN
+  Book ON book_id = Book.id
+WHERE
+  discard_date IS NULL
+  AND checkout_date > {fn TIMESTAMPADD(SQL_TSI_YEAR, -5, CURRENT_TIMESTAMP)}
+GROUP BY
+  Book.id,
+  Book.title,
+  Book.authors,
+  Book.publisher,
+  Book.register_date
+HAVING
+  Count(*) <= 5
+ORDER BY
+  Count(*) ASC;
+
+DISCONNECT;


### PR DESCRIPTION
貸出回数が少ない書籍（過去5年間における、貸出回数が0～5回の図書のリスト）をリストアップするsqlをレポジトリに追加しておきたいと思います。

PR作成時、どうやらアクセス権限の関係で https://github.com/hidekishima/pjsbookshelf/ に自動的にフォークする仕組みのようです。以下のようなメッセージが出ていました。
```
You’re creating a file in a project you don’t have write access to. Submitting a change will create the file in a new branch in your fork hidekishima/pjsbookshelf, so you can send a pull request.
```